### PR TITLE
muted the Issue #2 freetype bug

### DIFF
--- a/py2cd/__init__.py
+++ b/py2cd/__init__.py
@@ -40,8 +40,9 @@ from py2cd.rechteck import *
 from py2cd.kreis import *
 from py2cd.mathe import *
 from py2cd.animation import *
+
 # Text
-from py2cd.text import *
+# from py2cd.text import *
 # Bilder
 from py2cd.bild import *
 # Animationen

--- a/py2cd/spiel.py
+++ b/py2cd/spiel.py
@@ -2,7 +2,7 @@ import logging
 import sys
 
 import pygame
-import pygame.freetype
+# import pygame.freetype
 from pygame.constants import *
 
 import py2cd


### PR DESCRIPTION
A small workaround for #2 to keep py2cd running on a mac that doesn't realize that `freetype` is installed. 

This workaround comes with some drawbacks:
- spiel.py doesn't import the pygame.freetype module 
- py2cd doesn't load the Text class, so you can't display text
- `Spiel.zeichne_gitter()` doesn't work because it relies on the Text class

Would be the best to keep the workaround in a separate branch as long as the bug isn't resolved.
